### PR TITLE
Fix compilation with diagrams-lib 1.3.1.4

### DIFF
--- a/src/Diagrams/SVG/Tree.hs
+++ b/src/Diagrams/SVG/Tree.hs
@@ -47,7 +47,7 @@ import qualified Data.HashMap.Strict as H
 import qualified Data.Text as T
 import           Data.Text(Text(..))
 import           Data.Vector(Vector)
-import           Diagrams.Prelude
+import           Diagrams.Prelude hiding (Vector)
 import           Diagrams.TwoD.Size
 -- import           Diagrams.SVG.Fonts.ReadFont
 


### PR DESCRIPTION
Somehow a Vector type is exported from Diagrams.Prelude now, leading to the following compilation error:

    src\Diagrams\SVG\Tree.hs:543:17: error:
        Ambiguous occurrence `Vector'
        It could refer to either `Data.Vector.Vector',
                                 imported from `Data.Vector' at src\Diagrams\SVG\Tree.hs:49:30-35
                              or `Diagrams.Prelude.Vector',
                                 imported from `Diagrams.Prelude' at src\Diagrams\SVG\Tree.hs:50:1-33
                                 (and originally defined in `Data.Vector.Unboxed.Base')

This commit fixes the error by hiding the wrong Vector import.